### PR TITLE
Update the way Composer is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,22 @@ Role Variables
 
 Specify the path where Composer will be installed:
 
-    php_composer_install_path: /usr/local/bin/composer
+    php_composer_install_path: /usr/local/bin/composer.phar
+
+Composer relies on the INI directive `allow_url_fopen` turned on, and uses the `proc_open()` function.
+This goes against configuration best practices, so chances are Composer won't work in all circumstances.
+
+Another common issue is a memory limit, which is hit when computing a dependency graph.
+
+In order to have Composer function in all (or at least most) cases, a wrapper-script is installed.
+The following variables control how this wrapper functions:
+
+    php_composer_wrapper_enabled: yes
+    php_composer_wrapper_path: /usr/local/bin/composer
+    php_composer_wrapper_ini_directives:
+      allow_url_fopen: yes
+      disable_functions: ""
+      memory_limit: -1
 
 Dependencies
 ------------
@@ -29,7 +44,7 @@ Example Playbook
 
     - hosts: servers
       roles:
-        - { role: f500.php_composer, php_composer_install_path: /bin/composer }
+        - { role: f500.php_composer, php_composer_install_path: /usr/local/bin/composer, php_composer_wrapper_enabled: no }
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -1,13 +1,23 @@
 php_composer
-========
+============
 
-Install ComposerPHP
+Install [Composer](https://getcomposer.org/), the dependency manager for PHP.
 
 Requirements
 ------------
 
-Debian Wheezy/Jessie with the package python-pycurl and python-software-properties installed.
-In addition, it is assumed that the PHP-cli is already installed.
+This role is tailored towards Debian Wheezy / Jessie.
+
+The packages `python-apt` (or `python3-apt`) must be installed.
+
+In addition, it is assumed that the PHP CLI is already installed.
+
+Role Variables
+--------------
+
+Specify the path where Composer will be installed:
+
+    php_composer_install_path: /usr/local/bin/composer
 
 Dependencies
 ------------
@@ -19,16 +29,18 @@ Example Playbook
 
     - hosts: servers
       roles:
-         - { role: f500.php_composer }
+        - { role: f500.php_composer, php_composer_install_path: /bin/composer }
 
 License
 -------
 
-LGPL
+Copyright (C) 2017 Future500 B.V.
+
+[LGPL-3.0](https://github.com/f500/ansible-php_composer/blob/master/COPYING.LESSER)
 
 Author Information
 ------------------
 
-Jasper N. Brouwer, jasper@nerdsweide.nl
+Jasper N. Brouwer, jasper@future500.nl
 
-Ramon de la Fuente, ramon@delafuente.nl
+Ramon de la Fuente, ramon@future500.nl

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,10 @@
 ---
 
-php_composer_install_path: /usr/local/bin/composer
+php_composer_install_path: /usr/local/bin/composer.phar
+
+php_composer_wrapper_enabled: yes
+php_composer_wrapper_path: /usr/local/bin/composer
+php_composer_wrapper_ini_directives:
+  allow_url_fopen: yes
+  disable_functions: ""
+  memory_limit: -1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+php_composer_install_path: /usr/local/bin/composer

--- a/files/composer
+++ b/files/composer
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-php -d allow_url_fopen=On /usr/local/bin/composer.phar $@

--- a/files/composer-install.sh
+++ b/files/composer-install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 EXPECTED_SIGNATURE=$(wget -q -O - https://composer.github.io/installer.sig)
-php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+php -d allow_url_fopen=On -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
 
 if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
@@ -11,7 +11,7 @@ then
     exit 1
 fi
 
-php composer-setup.php --quiet
+php -d allow_url_fopen=On composer-setup.php --quiet
 RESULT=$?
 rm composer-setup.php
 exit $RESULT

--- a/files/composer-install.sh
+++ b/files/composer-install.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+EXPECTED_SIGNATURE=$(wget -q -O - https://composer.github.io/installer.sig)
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,9 +1,10 @@
 ---
+
 galaxy_info:
   author: "Jasper N. Brouwer, Ramon de la Fuente"
-  description: Install ComposerPHP
+  description: Install Composer, the dependency manager for PHP
   company: Future500
-  license: LGPL
+  license: LGPL-3.0
   min_ansible_version: 1.4
   platforms:
   - name: Debian
@@ -13,4 +14,3 @@ galaxy_info:
   categories:
     - web
     - system
-dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,3 +34,10 @@
 - name: Move Composer to the install path
   command: mv /tmp/composer.phar "{{ php_composer_install_path }}"
   when: not php_composer_binary.stat.exists
+
+- name: Enable the wrapper
+  template:
+    src: composer.j2
+    dest: "{{ php_composer_wrapper_path }}"
+    mode: 0755
+  when: php_composer_wrapper_enabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,36 @@
 ---
 
-- name: install composer
-  shell: curl -sS https://getcomposer.org/installer | php -d allow_url_fopen=On chdir=/usr/local/bin creates=/usr/local/bin/composer.phar
+- name: Check if Composer is installed
+  stat:
+    path: "{{ php_composer_install_path }}"
+  register: php_composer_binary
 
-- name: install composer bash-script
-  copy: src=composer dest=/usr/local/bin/composer owner=root group=root mode=0755
+- name: Install packages needed to install Composer
+  apt:
+    name: "{{ item }}"
+  with_items:
+    - wget
+  when: not php_composer_binary.stat.exists
+
+- name: Create the install script
+  copy:
+    src: composer-install.sh
+    dest: /tmp/composer-install.sh
+    mode: 0755
+  when: not php_composer_binary.stat.exists
+
+- name: Install Composer
+  command: ./composer-install.sh
+  args:
+    chdir: /tmp
+  when: not php_composer_binary.stat.exists
+
+- name: Remove the install script
+  file:
+    path: /tmp/composer-install.sh
+    state: absent
+  when: not php_composer_binary.stat.exists
+
+- name: Move Composer to the install path
+  command: mv /tmp/composer.phar "{{ php_composer_install_path }}"
+  when: not php_composer_binary.stat.exists

--- a/templates/composer.j2
+++ b/templates/composer.j2
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+exec php \
+{% for key, value in php_composer_wrapper_ini_directives.iteritems() %}
+{% if value is sameas True %}
+-d {{ key }}=On \
+{% elif value is sameas False %}
+-d {{ key }}=Off \
+{% elif value is number %}
+-d {{ key }}={{ value }} \
+{% else %}
+-d {{ key }}="{{ value }}" \
+{% endif %}
+{% endfor %}
+{{ php_composer_install_path }} "$@"


### PR DESCRIPTION
- Follow the recommendations on installing Composer programmatically.
- Add an install-path variable to be able to control where Composer ends up.
- Improve the wrapper script, adding variables to control how it works.

I think this the next version could be tagged as `v2.1.0` (instead of `v3.0.0`), because there are no BC breaks as far as I can see. Although the installation process is quite different, by default the composer binary/script still ends up in `/usr/local/bin/composer.phar` and the wrapper script in `/usr/local/bin/composer`.